### PR TITLE
change export_items to CharField to avoid exceeding POST parameter limit

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -9,7 +9,7 @@ from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.auth import get_permission_codename
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError, PermissionDenied
-from django.forms import MultipleChoiceField, MultipleHiddenInput
+from django.forms import CharField, HiddenInput
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.template.response import TemplateResponse
@@ -26,6 +26,7 @@ from .mixins import BaseExportMixin, BaseImportMixin
 from .results import RowResult
 from .signals import post_export, post_import
 from .tmp_storages import TempFolderStorage
+from .validators import ExportItemsValidator
 
 logger = logging.getLogger(__name__)
 
@@ -758,10 +759,11 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         if request.POST and f"{FORM_FIELD_PREFIX}export_items" in request.POST:
             # this field is instantiated if the export is POSTed from the
             # 'action' drop down
-            form.fields["export_items"] = MultipleChoiceField(
-                widget=MultipleHiddenInput,
+            form.fields["export_items"] = CharField(
+                widget=HiddenInput,
                 required=False,
-                choices=[(pk, pk) for pk in queryset.values_list("pk", flat=True)],
+                initial=",".join(map(str, queryset.values_list("pk", flat=True))),
+                validators=[ExportItemsValidator(self, request)],
             )
         if form.is_valid():
             file_format = formats[int(form.cleaned_data["format"])]()
@@ -770,7 +772,12 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
                 # this request has arisen from an Admin UI action
                 # export item pks are stored in form data
                 # so generate the queryset from the stored pks
-                queryset = queryset.filter(pk__in=form.cleaned_data["export_items"])
+                if export_items_str := form.cleaned_data.get("export_items"):
+                    export_ids = [
+                        str(item).strip()
+                        for item in export_items_str.strip("[]").split(",")
+                    ]
+                    queryset = queryset.filter(pk__in=export_ids)
 
             try:
                 return self._do_file_export(
@@ -893,14 +900,15 @@ class ExportActionMixin(ExportMixin):
         form_type = self.get_export_form_class()
         formats = self.get_export_formats()
         export_items = list(queryset.values_list("pk", flat=True))
+        export_items_str = ",".join([str(pk) for pk in export_items])
         form = form_type(
             formats=formats,
             resources=self.get_export_resource_classes(request),
-            initial={"export_items": export_items},
+            initial={"export_items": export_items_str},
         )
         # selected items are to be stored as a hidden input on the form
-        form.fields["export_items"] = MultipleChoiceField(
-            widget=MultipleHiddenInput, required=False, choices=export_items
+        form.fields["export_items"] = CharField(
+            widget=HiddenInput, required=False, initial=export_items_str
         )
         context = self.init_request_context_data(request, form)
 
@@ -921,6 +929,7 @@ class ExportActionMixin(ExportMixin):
             export_url += "?" + urlencode(request.GET)
 
         context["export_url"] = export_url
+        context["export_items_length"] = len(export_items)
 
         return render(request, "admin/import_export/export.html", context=context)
 

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -113,9 +113,7 @@ class ConfirmImportForm(FieldNamePrefixMixin, forms.Form):
 
 
 class ExportForm(ImportExportFormBase):
-    export_items = forms.MultipleChoiceField(
-        widget=forms.MultipleHiddenInput(), required=False
-    )
+    export_items = forms.CharField(widget=forms.HiddenInput(), required=False)
 
 
 class SelectableFieldsExportForm(ExportForm):

--- a/import_export/templates/admin/import_export/export.html
+++ b/import_export/templates/admin/import_export/export.html
@@ -18,7 +18,7 @@
     {# export request has originated from an Admin UI action #}
     {% if form.initial.export_items %}
       <p>
-      {% blocktranslate count len=form.initial.export_items|length trimmed %}
+      {% blocktranslate count len=export_items_length trimmed %}
         Export {{ len }} selected item.
         {% plural %}
         Export {{ len }} selected items.

--- a/import_export/validators.py
+++ b/import_export/validators.py
@@ -1,0 +1,20 @@
+from django.core.exceptions import ValidationError
+
+
+class ExportItemsValidator:
+    def __init__(self, admin_instance, request):
+        self.admin_instance = admin_instance
+        self.request = request
+
+    def __call__(self, value):
+        export_ids = {str(i).strip() for i in value.strip("[]").split(",")}
+        valid_ids = {
+            str(pk)
+            for pk in self.admin_instance.get_valid_export_item_pks(self.request)
+        }
+        invalid_ids = export_ids - valid_ids
+        if invalid_ids:
+            raise ValidationError(
+                "Select a valid choice. "
+                f"{','.join(invalid_ids)} is not one of the available choices."
+            )

--- a/import_export/validators.py
+++ b/import_export/validators.py
@@ -8,10 +8,8 @@ class ExportItemsValidator:
 
     def __call__(self, value):
         export_ids = {str(i).strip() for i in value.strip("[]").split(",")}
-        valid_ids = {
-            str(pk)
-            for pk in self.admin_instance.get_valid_export_item_pks(self.request)
-        }
+        queryset = self.admin_instance.get_export_queryset(self.request)
+        valid_ids = {str(pk) for pk in queryset.values_list("pk", flat=True)}
         invalid_ids = export_ids - valid_ids
         if invalid_ids:
             raise ValidationError(

--- a/tests/core/tests/admin_integration/test_action_export.py
+++ b/tests/core/tests/admin_integration/test_action_export.py
@@ -59,7 +59,9 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertIn("form", response.context)
         export_form = response.context["form"]
         data = export_form.initial
-        self.assertEqual([self.cat1.id], data["export_items"])
+        export_items_str = data["export_items"]
+        export_items = [int(item) for item in export_items_str.split(",")]
+        self.assertEqual([self.cat1.id], export_items)
         self.assertIn("Export 1 selected item.", response.content.decode())
 
     def test_export_displays_ui_select_page_multiple_items(self):
@@ -71,9 +73,9 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertIn("form", response.context)
         export_form = response.context["form"]
         data = export_form.initial
-        self.assertEqual(
-            sorted([self.cat1.id, self.cat2.id]), sorted(data["export_items"])
-        )
+        export_items_str = data["export_items"]
+        export_items = [int(item) for item in export_items_str.split(",")]
+        self.assertEqual(sorted([self.cat1.id, self.cat2.id]), sorted(export_items))
         self.assertIn("Export 2 selected items.", response.content.decode())
 
     def test_action_export_model_with_custom_PK(self):
@@ -87,7 +89,9 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertIn("form", response.context)
         export_form = response.context["form"]
         data = export_form.initial
-        self.assertEqual([cat.pk], data["export_items"])
+        export_items_str = data["export_items"]
+        export_items = [str(item) for item in export_items_str.split(",")]
+        self.assertEqual([str(cat.pk)], export_items)
         self.assertIn("Export 1 selected item.", response.content.decode())
 
     def test_export_post(self):
@@ -130,7 +134,7 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
     def test_export_admin_action_with_restricted_pks(self):
         data = {
             "format": "0",
-            "export_items": [str(self.cat1.id)],
+            "export_items": str(self.cat1.id),
             **self.resource_fields_payload,
         }
         self._prepend_form_prefix(data)

--- a/tests/core/tests/admin_integration/test_action_export.py
+++ b/tests/core/tests/admin_integration/test_action_export.py
@@ -339,7 +339,7 @@ class TestExportFilterPreservation(AdminTestMixin, TestCase):
         # Step 2: Now submit the export form to the preserved URL
         export_data = {
             "format": "0",
-            "export_items": [str(self.old_book1.id), str(self.old_book2.id)],
+            "export_items": f"[{str(self.old_book1.id)},{str(self.old_book2.id)}]",
             **self.resource_fields_payload,
         }
         self._prepend_form_prefix(export_data)


### PR DESCRIPTION
**Problem**

When exporting many rows (>1000), too many fields are added to the request and rasies [SuspiciousOperation](https://docs.djangoproject.com/en/5.1/ref/exceptions/#django.core.exceptions.SuspiciousOperation) (TooManyFields)

**Solution**

changed the form from a multiselect, to a string, so all fields are added to a single string
